### PR TITLE
John/persist query keys between refresh, unit tests, and improved code organization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Run Tests
+on: 
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+jobs:
+  unit-testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Tests and Build
 on: 
   pull_request:
     branches:

--- a/__tests__/saveSelectedQueryKeys.ts
+++ b/__tests__/saveSelectedQueryKeys.ts
@@ -1,0 +1,56 @@
+import saveSelectedQueryKeys from "../src/functions/saveSelectedQueryKeys";
+
+// Based on: https://elvisciotti.medium.com/create-a-working-chrome-storage-your-chrome-edge-browser-extension-during-testing-with-jest-071d69fcf8a1
+
+// mock chrome extension get and set functions
+let localStorage: any = {
+  thisSessionsQueries: undefined,
+  selectedQueries: undefined
+};
+
+global.chrome = {
+  storage: {
+    local: {
+      clear: () => {
+        localStorage = {
+          thisSessionsQueries: undefined,
+          selectedQueries: undefined
+        }
+      },
+      // set takes in obj with key thisSessionsQueries or selectedQueries and the value that will be stored
+      set: (newValue: any) => { 
+        localStorage = { ...localStorage, ...newValue };
+      },
+      // get returns a promise that resolves to an object with key value pairs 
+      get: (key: any) => {
+        return Promise.resolve({ [key]: localStorage[key] });
+      }
+    },
+  }
+} as unknown as typeof chrome;
+
+
+describe('saveSelectedQueryKeys basic tests', () => {
+  // clear info stored in mock function calls and their arrays 
+  beforeEach(() => {
+    chrome.storage.local.clear();
+  });
+
+  it('should set storage to empty array when queries is an empty array and no previous data is stored', async () => {
+    await saveSelectedQueryKeys([]);
+
+    expect(localStorage).toEqual({
+      thisSessionsQueries: [],
+      selectedQueries: []
+    });
+  })
+
+  it('should set storage to when passed an array with an queryKey in it', async () => {
+    await saveSelectedQueryKeys(['[queryKeyTest]'])
+
+    expect(localStorage).toEqual({
+      thisSessionsQueries: ['[queryKeyTest]'],
+      selectedQueries: ['[queryKeyTest]']
+    });
+  })
+});

--- a/jestConfig/fileTransform.js
+++ b/jestConfig/fileTransform.js
@@ -1,6 +1,7 @@
 // fileTransform.js
 const path = require('path');
 
+// Importing images is a way to include them in your browser bundle, but they are not valid JavaScript. One way of handling it in Jest is to replace the imported value with its filename.
 module.exports = {
   process(src, filename) {
     return `module.exports = ${JSON.stringify(path.basename(filename))};`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,6 @@ function App() {
   const handleSelectionChange = (queries: string[]) => {
     setSelectedQueries(queries);
     saveSelectedQueryKeys(queries);
-  
   };
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import ParentTab from './containers/ParentTab';
 import { QueryEvent } from './types';
 import MultiSelect from './components/MultiSelect';
-
+import saveSelectedQueryKeys from './functions/saveSelectedQueryKeys'
 import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import { createTheme } from '@mui/material/styles';
@@ -53,61 +53,8 @@ function App() {
   // updates state for selected queries
   const handleSelectionChange = (queries: string[]) => {
     setSelectedQueries(queries);
-
-    // *** Persisting Query Selection ***
-    // this is complex because we may store queries that are not yet visible in the drop-down
-
-    // *** Refactor notes: handle errors (maybe update to promises)
-
-    // set thisSessionsQueries to the queries array the function takes in because on page load, queries will be an empty array, effectively resetting it. If queries is an empty array, we initialize it here to an empty array. When queries is not empty, we will set it at the end of the function
-    if (queries.length === 0) {
-      chrome.storage.local.set({ thisSessionsQueries: queries });
-    }
-
-    // to allow users to remove queries, we will separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed
-    const queriesSet = new Set(queries);
-    chrome.storage.local.get(['thisSessionsQueries'], (result) => {
-      if (
-        result.thisSessionsQueries &&
-        Array.isArray(result.thisSessionsQueries)
-      ) {
-        const queriesRemoved: string[] = [];
-        for (const queryKey of result.thisSessionsQueries) {
-          if (!queriesSet.has(queryKey)) {
-            queriesRemoved.push(queryKey);
-          }
-        }
-
-        // get the query keys that were stored from previous sessions
-        chrome.storage.local.get(['selectedQueries'], (result) => {
-          // get the queries out of local storage and store them as an array
-          let existingQueries: string[] = [];
-          if (result.selectedQueries && Array.isArray(result.selectedQueries)) {
-            existingQueries = result.selectedQueries;
-          }
-
-          // combine existing queries with the new ones and handle duplicates
-          const combinedQueries = new Set([...existingQueries, ...queries]);
-          // remove the queries that users unselected
-          const combinedQueriesWithRemovals: string[] = [];
-          for (const queryKey of combinedQueries) {
-            // if queryKey is not in the removals list, add it to be stored
-            if (!queriesRemoved.includes(queryKey)) {
-              // store as a set for faster access
-              combinedQueriesWithRemovals.push(queryKey);
-            }
-          }
-
-          // add the combinedQueries into local storage
-          chrome.storage.local.set({
-            selectedQueries: combinedQueriesWithRemovals,
-          });
-
-          // update storage for current session's selections
-          chrome.storage.local.set({ thisSessionsQueries: queries });
-        });
-      }
-    });
+    saveSelectedQueryKeys(queries);
+  
   };
 
   return (

--- a/src/components/JsonDiff.tsx
+++ b/src/components/JsonDiff.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import JsonFormatter from './JsonFormatter';
 import Typography from '@mui/material/Typography';
-
 import Container from '@mui/material/Container';
 import jsondiffpatch from 'jsondiffpatch';
 import '../css/jsonDiff.css';
+import { JsonDataType } from '../types';
 
-type JsonDataType = {
-  [key: string]: any;
-};
 
 type JsonFormatterType = {
   oldJson?: JsonDataType | string, // optional in case you're on first state

--- a/src/components/JsonDiff.tsx
+++ b/src/components/JsonDiff.tsx
@@ -4,22 +4,11 @@ import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import jsondiffpatch from 'jsondiffpatch';
 import '../css/jsonDiff.css';
-import { JsonDataType } from '../types';
+import { JsonDiffType } from '../types';
 
 
-type JsonFormatterType = {
-  oldJson?: JsonDataType | string, // optional in case you're on first state
-  currentJson: JsonDataType | string, // or string since state gets initialized to an empty string
-  queryKey: string,
-  isHidden: boolean
-};
+const JsonDiff: React.FC<JsonDiffType> = ({ oldJson, currentJson, queryKey, isHidden }) => {
 
-
-const JsonDiff: React.FC<JsonFormatterType> = ({ oldJson, currentJson, queryKey, isHidden }) => {
-  // console.log('QueryKey: ', queryKey);
-  // console.log('old:', oldJson);
-  // console.log('currentJson:', currentJson);
-  
   // handle scenario where we're on the first state - getting currentJson but not oldJson
   if (currentJson === '') return (
     <Typography

--- a/src/components/JsonFormatter.tsx
+++ b/src/components/JsonFormatter.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
 import { JSONTree } from 'react-json-tree';
-import { ExpandNodesFuncType, JsonDataType } from '../types';
+import { JsonFormatterType } from '../types';
 
 
 // https://github.com/reduxjs/redux-devtools/tree/75322b15ee7ba03fddf10ac3399881e302848874/src/react/themes
 const theme = {
   base00: 'transparent',
-};
-
-type JsonFormatterType = {
-  jsonData: JsonDataType;
-  queryKey: string;
-  expandNodesFunc?: ExpandNodesFuncType; // this should be required but getting errors when it's not
 };
 
 const JsonFormatter: React.FC<JsonFormatterType> = ({ jsonData, queryKey, expandNodesFunc }) => {

--- a/src/components/JsonFormatter.tsx
+++ b/src/components/JsonFormatter.tsx
@@ -20,7 +20,7 @@ type ExpandNodesFuncType = (
 type JsonFormatterType = {
   jsonData: JsonDataType;
   queryKey: string;
-  expandNodesFunc: ExpandNodesFuncType;
+  expandNodesFunc?: ExpandNodesFuncType; // this should be required but getting errors when it's not
 };
 
 const JsonFormatter: React.FC<JsonFormatterType> = ({ jsonData, queryKey, expandNodesFunc }) => {

--- a/src/components/JsonFormatter.tsx
+++ b/src/components/JsonFormatter.tsx
@@ -6,34 +6,26 @@ const theme = {
   base00: 'transparent',
 };
 
-// Types
+// Types - should be brought into global types file so code is more DRY?
 type JsonDataType = {
   [key: string]: any;
 };
+
+type ExpandNodesFuncType = (
+  keyPath: ReadonlyArray<string | number>,
+  value: any,
+  layer: number
+) => boolean;
+
 type JsonFormatterType = {
   jsonData: JsonDataType;
   queryKey: string;
+  expandNodesFunc: ExpandNodesFuncType;
 };
 
-const JsonFormatter: React.FC<JsonFormatterType> = ({ jsonData, queryKey }) => {
+const JsonFormatter: React.FC<JsonFormatterType> = ({ jsonData, queryKey, expandNodesFunc }) => {
   // update data so that query key is the root
   const dataWithKey = { [queryKey]: jsonData };
-
-  // function to expand nodes
-  const expand = (
-    keyPath: ReadonlyArray<string | number>,
-    value: any,
-    layer: number
-  ) => {
-    // Gets recurisved called and traverses the json in depth first search so we could use it to trac the nodes that are open at any given time
-
-    // console.log('keyPath: ', keyPath); // keyPath: the keyPaths (goes in a recursive, depth first approach)
-    // console.log('value: ', value); // value: value in that keypath
-    // console.log('layer: ', layer); // layer: the depth
-    // expand first level
-    if (layer < 2) return true;
-    return false;
-  };
 
   return (
     <div>
@@ -41,7 +33,7 @@ const JsonFormatter: React.FC<JsonFormatterType> = ({ jsonData, queryKey }) => {
         data={dataWithKey}
         theme={theme}
         hideRoot={true}
-        shouldExpandNodeInitially={expand}
+        shouldExpandNodeInitially={expandNodesFunc}
       />
     </div>
   );

--- a/src/components/JsonFormatter.tsx
+++ b/src/components/JsonFormatter.tsx
@@ -1,21 +1,12 @@
 import React from 'react';
 import { JSONTree } from 'react-json-tree';
+import { ExpandNodesFuncType, JsonDataType } from '../types';
+
 
 // https://github.com/reduxjs/redux-devtools/tree/75322b15ee7ba03fddf10ac3399881e302848874/src/react/themes
 const theme = {
   base00: 'transparent',
 };
-
-// Types - should be brought into global types file so code is more DRY?
-type JsonDataType = {
-  [key: string]: any;
-};
-
-type ExpandNodesFuncType = (
-  keyPath: ReadonlyArray<string | number>,
-  value: any,
-  layer: number
-) => boolean;
 
 type JsonFormatterType = {
   jsonData: JsonDataType;

--- a/src/components/MultiSelect.tsx
+++ b/src/components/MultiSelect.tsx
@@ -27,7 +27,9 @@ export default function MultiSelect({
     // when there are new query options, we need to check with local storage and see if any of them are set
     chrome.storage.local.get(['selectedQueries'], (result) => {
       // check that data exists and it's an array
+      // console.log('result when setting queries: ', result);
       if (result.selectedQueries && Array.isArray(result.selectedQueries)) {
+        // console.log('criteria is met');
         // get the queries out of local storage
         const arrayQueries = result.selectedQueries;
         const intersectionOfStorageAndAvailable: string[] = [];

--- a/src/containers/DiffTab.tsx
+++ b/src/containers/DiffTab.tsx
@@ -3,6 +3,8 @@ import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 import React, { useState } from 'react';
+import { JsonDataType } from '../types';
+
 
 import JsonDiff from '../components/JsonDiff';
 

--- a/src/containers/DiffTab.tsx
+++ b/src/containers/DiffTab.tsx
@@ -3,7 +3,6 @@ import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Switch from '@mui/material/Switch';
 import React, { useState } from 'react';
-import { JsonDataType } from '../types';
 
 
 import JsonDiff from '../components/JsonDiff';

--- a/src/containers/StateTab.tsx
+++ b/src/containers/StateTab.tsx
@@ -22,10 +22,10 @@ const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
     layer: number
   ): boolean => {
     // Gets recurisved called and traverses the json in depth first search so we could use it to trac the nodes that are open at any given time
-    console.log('Func called');
-    console.log('keyPath: ', keyPath); // keyPath: the keyPaths (goes in a recursive, depth first approach)
-    console.log('value: ', value); // value: value in that keypath
-    console.log('layer: ', layer); // layer: the depth
+    // console.log('Func called');
+    // console.log('keyPath: ', keyPath); // keyPath: the keyPaths (goes in a recursive, depth first approach)
+    // console.log('value: ', value); // value: value in that keypath
+    // console.log('layer: ', layer); // layer: the depth
     // expand first level
 
 

--- a/src/containers/StateTab.tsx
+++ b/src/containers/StateTab.tsx
@@ -4,6 +4,12 @@ import JsonFormatter from '../components/JsonFormatter';
 import { useState } from 'react';
 import { DataTabProps } from '../types';
 
+type ExpandNodesFuncType = (
+  keyPath: ReadonlyArray<string | number>,
+  value: any,
+  layer: number
+) => boolean;
+
 const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
   // state to handle open nodes
   const [openNodes, setOpenNodes] = useState(new Set());
@@ -14,7 +20,7 @@ const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
     keyPath: ReadonlyArray<string | number>,
     value: any,
     layer: number
-  ) => {
+  ): boolean => {
     // Gets recurisved called and traverses the json in depth first search so we could use it to trac the nodes that are open at any given time
     console.log('Func called');
     console.log('keyPath: ', keyPath); // keyPath: the keyPaths (goes in a recursive, depth first approach)

--- a/src/containers/StateTab.tsx
+++ b/src/containers/StateTab.tsx
@@ -1,8 +1,30 @@
 import JsonFormatter from '../components/JsonFormatter';
-
+import { useState } from 'react';
 import { DataTabProps } from '../types';
 
 const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
+  // state to handle open nodes
+  const [openNodes, setOpenNodes] = useState(new Set());
+  // each item in the set the keyValue
+
+  // function to expand nodes (types can probably be stored globally so code is more dry)
+  const expandNodesFunc = (
+    keyPath: ReadonlyArray<string | number>,
+    value: any,
+    layer: number
+  ) => {
+    // Gets recurisved called and traverses the json in depth first search so we could use it to trac the nodes that are open at any given time
+    console.log('Func called');
+    console.log('keyPath: ', keyPath); // keyPath: the keyPaths (goes in a recursive, depth first approach)
+    console.log('value: ', value); // value: value in that keypath
+    console.log('layer: ', layer); // layer: the depth
+    // expand first level
+
+
+    if (layer < 2) return true;
+    return false;
+  };
+
   return (
     <>
       {queryDisplay.length > 0 && queryDisplay[currentIndex] && (
@@ -16,6 +38,7 @@ const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
                 key={queryState.queryKey}
                 queryKey={queryState.queryKey}
                 jsonData={queryState.queryData}
+                expandNodesFunc={expandNodesFunc}
               />
             </>
           ))}

--- a/src/containers/StateTab.tsx
+++ b/src/containers/StateTab.tsx
@@ -3,11 +3,6 @@ import JsonFormatter from '../components/JsonFormatter';
 import { useState } from 'react';
 import { DataTabProps, ExpandNodesFuncType } from '../types';
 
-// type ExpandNodesFuncType = (
-//   keyPath: ReadonlyArray<string | number>,
-//   value: any,
-//   layer: number
-// ) => boolean;
 
 const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
   // state to handle open nodes
@@ -26,7 +21,6 @@ const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
     // console.log('value: ', value); // value: value in that keypath
     // console.log('layer: ', layer); // layer: the depth
     // expand first level
-
 
     if (layer < 2) return true;
     return false;

--- a/src/containers/StateTab.tsx
+++ b/src/containers/StateTab.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-
 import JsonFormatter from '../components/JsonFormatter';
 import { useState } from 'react';
-import { DataTabProps } from '../types';
+import { DataTabProps, ExpandNodesFuncType } from '../types';
 
-type ExpandNodesFuncType = (
-  keyPath: ReadonlyArray<string | number>,
-  value: any,
-  layer: number
-) => boolean;
+// type ExpandNodesFuncType = (
+//   keyPath: ReadonlyArray<string | number>,
+//   value: any,
+//   layer: number
+// ) => boolean;
 
 const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
   // state to handle open nodes
@@ -16,11 +15,11 @@ const StateTab = ({ queryDisplay, currentIndex }: DataTabProps) => {
   // each item in the set the keyValue
 
   // function to expand nodes (types can probably be stored globally so code is more dry)
-  const expandNodesFunc = (
-    keyPath: ReadonlyArray<string | number>,
-    value: any,
-    layer: number
-  ): boolean => {
+  const expandNodesFunc: ExpandNodesFuncType = (
+    keyPath,
+    value,
+    layer
+  ) => {
     // Gets recurisved called and traverses the json in depth first search so we could use it to trac the nodes that are open at any given time
     // console.log('Func called');
     // console.log('keyPath: ', keyPath); // keyPath: the keyPaths (goes in a recursive, depth first approach)

--- a/src/functions/saveSelectedQueryKeys.ts
+++ b/src/functions/saveSelectedQueryKeys.ts
@@ -1,20 +1,12 @@
 
 const saveSelectedQueryKeys = async (queries: string[]) => {
-  console.log('*** FUNC INVOKED ****');
-
-  // TESTING - delete later
-  const finalSessionResultBEFORE = await chrome.storage.local.get(['thisSessionsQueries']);
-  console.log('SessionQueries BEFORE: ', finalSessionResultBEFORE.thisSessionsQueries);
-  const finalResultBEFORE = await chrome.storage.local.get(['selectedQueries']);
-  console.log('final BEFORE: ', finalResultBEFORE.selectedQueries);
-  
   // *** Persisting Query Selection ***
   // this is complex because we may store queries that are not yet visible in the drop-down
 
   // to allow users to remove queries, we separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed by comparies the queries that come in as an arguement to the queries that were previously selected
   // once we have the query keys that were removed, we update the storage to be: union of what's currently stored and what was added. Less any queries that were removed
   
-  // clear session queries when first invoked:
+  // clear session queries when first invoked. This always happens with an empty queries array
   if (queries.length === 0) {
     await chrome.storage.local.set({
       thisSessionsQueries: []
@@ -33,10 +25,8 @@ const saveSelectedQueryKeys = async (queries: string[]) => {
   // determine the queries that the user removed by finding the difference between the queries passed into the function and the queries stored as SessionQueries
   // I'm currently marking queries as removed 
   const queriesRemoved: string[] = sessionQueries.filter( queryKey => !queriesSet.has(queryKey))
-  console.log('queriesRemoved: ', queriesRemoved );
 
   // update storage for current session's selections now that we've found if any query keys were removed 
-  console.log('queries: ', queries);
   await chrome.storage.local.set({
     thisSessionsQueries: queries
   });
@@ -44,7 +34,6 @@ const saveSelectedQueryKeys = async (queries: string[]) => {
 
   // get the query keys that were selected in previous sessions
   const selectedResult = await chrome.storage.local.get(['selectedQueries'])
-  console.log('From previous session: ', selectedResult.selectedQueries);
 
   // if no queries have been stored as part of previous sessions set to an empty array
   const selectedQueries: string[] =
@@ -54,7 +43,6 @@ const saveSelectedQueryKeys = async (queries: string[]) => {
 
   // combine existing queries with the new ones and handle duplicates
   const combinedQueries = new Set([...selectedQueries, ...queries]);
-  console.log('combinedQueries: ', selectedQueries);
 
   // remove the queries that users unselected
   const combinedQueriesWithRemovals: string[] = [];
@@ -67,16 +55,9 @@ const saveSelectedQueryKeys = async (queries: string[]) => {
   }
 
   // add the combinedQueries into local storage
-  console.log('combinedQueriesWithRemovals: ', combinedQueriesWithRemovals);
   await chrome.storage.local.set({
     selectedQueries: combinedQueriesWithRemovals,
   });
-
-  // TESTING - delete later
-  const finalSessionResult = await chrome.storage.local.get(['thisSessionsQueries']);
-  console.log('SessionQueries AFTER: ', finalSessionResult.thisSessionsQueries);
-  const finalResult = await chrome.storage.local.get(['selectedQueries']);
-  console.log('final AFTER: ', finalResult.selectedQueries);
 };
 
 export default saveSelectedQueryKeys;

--- a/src/functions/saveSelectedQueryKeys.ts
+++ b/src/functions/saveSelectedQueryKeys.ts
@@ -1,59 +1,59 @@
 
 const saveSelectedQueryKeys = async (queries: string[]) => {
-    // *** Persisting Query Selection ***
-    // this is complex because we may store queries that are not yet visible in the drop-down
+  // *** Persisting Query Selection ***
+  // this is complex because we may store queries that are not yet visible in the drop-down
 
-    // *** Refactor notes: handle errors (maybe update to promises)
+  // *** Refactor notes: handle errors (maybe update to promises)
 
-    // set thisSessionsQueries to the queries array the function takes in because on page load, queries will be an empty array, effectively resetting it. If queries is an empty array, we initialize it here to an empty array. When queries is not empty, we will set it at the end of the function
-    if (queries.length === 0) {
-      await chrome.storage.local.set({ thisSessionsQueries: queries });
-    }
+  // set thisSessionsQueries to the queries array the function takes in because on page load, queries will be an empty array, effectively resetting it. If queries is an empty array, we initialize it here to an empty array. When queries is not empty, we will set it at the end of the function
+  if (queries.length === 0) {
+    await chrome.storage.local.set({ thisSessionsQueries: queries });
+  }
 
-    // to allow users to remove queries, we will separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed
-    const queriesSet = new Set(queries);
-    chrome.storage.local.get(['thisSessionsQueries'], (result) => {
-      if (
-        result.thisSessionsQueries &&
-        Array.isArray(result.thisSessionsQueries)
-      ) {
-        const queriesRemoved: string[] = [];
-        for (const queryKey of result.thisSessionsQueries) {
-          if (!queriesSet.has(queryKey)) {
-            queriesRemoved.push(queryKey);
+  // to allow users to remove queries, we will separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed
+  const queriesSet = new Set(queries);
+  chrome.storage.local.get(['thisSessionsQueries'], (result) => {
+    if (
+      result.thisSessionsQueries &&
+      Array.isArray(result.thisSessionsQueries)
+    ) {
+      const queriesRemoved: string[] = [];
+      for (const queryKey of result.thisSessionsQueries) {
+        if (!queriesSet.has(queryKey)) {
+          queriesRemoved.push(queryKey);
+        }
+      }
+
+      // get the query keys that were stored from previous sessions
+      chrome.storage.local.get(['selectedQueries'], (result) => {
+        // get the queries out of local storage and store them as an array
+        let existingQueries: string[] = [];
+        if (result.selectedQueries && Array.isArray(result.selectedQueries)) {
+          existingQueries = result.selectedQueries;
+        }
+
+        // combine existing queries with the new ones and handle duplicates
+        const combinedQueries = new Set([...existingQueries, ...queries]);
+        // remove the queries that users unselected
+        const combinedQueriesWithRemovals: string[] = [];
+        for (const queryKey of combinedQueries) {
+          // if queryKey is not in the removals list, add it to be stored
+          if (!queriesRemoved.includes(queryKey)) {
+            // store as a set for faster access
+            combinedQueriesWithRemovals.push(queryKey);
           }
         }
 
-        // get the query keys that were stored from previous sessions
-        chrome.storage.local.get(['selectedQueries'], (result) => {
-          // get the queries out of local storage and store them as an array
-          let existingQueries: string[] = [];
-          if (result.selectedQueries && Array.isArray(result.selectedQueries)) {
-            existingQueries = result.selectedQueries;
-          }
-
-          // combine existing queries with the new ones and handle duplicates
-          const combinedQueries = new Set([...existingQueries, ...queries]);
-          // remove the queries that users unselected
-          const combinedQueriesWithRemovals: string[] = [];
-          for (const queryKey of combinedQueries) {
-            // if queryKey is not in the removals list, add it to be stored
-            if (!queriesRemoved.includes(queryKey)) {
-              // store as a set for faster access
-              combinedQueriesWithRemovals.push(queryKey);
-            }
-          }
-
-          // add the combinedQueries into local storage
-          chrome.storage.local.set({
-            selectedQueries: combinedQueriesWithRemovals,
-          });
-
-          // update storage for current session's selections
-          chrome.storage.local.set({ thisSessionsQueries: queries });
+        // add the combinedQueries into local storage
+        chrome.storage.local.set({
+          selectedQueries: combinedQueriesWithRemovals,
         });
-      }
-    });
-  };
+
+        // update storage for current session's selections
+        chrome.storage.local.set({ thisSessionsQueries: queries });
+      });
+    }
+  });
+};
 
 export default saveSelectedQueryKeys;

--- a/src/functions/saveSelectedQueryKeys.ts
+++ b/src/functions/saveSelectedQueryKeys.ts
@@ -1,59 +1,82 @@
 
 const saveSelectedQueryKeys = async (queries: string[]) => {
+  console.log('*** FUNC INVOKED ****');
+
+  // TESTING - delete later
+  const finalSessionResultBEFORE = await chrome.storage.local.get(['thisSessionsQueries']);
+  console.log('SessionQueries BEFORE: ', finalSessionResultBEFORE.thisSessionsQueries);
+  const finalResultBEFORE = await chrome.storage.local.get(['selectedQueries']);
+  console.log('final BEFORE: ', finalResultBEFORE.selectedQueries);
+  
   // *** Persisting Query Selection ***
   // this is complex because we may store queries that are not yet visible in the drop-down
 
-  // *** Refactor notes: handle errors (maybe update to promises)
-
-  // set thisSessionsQueries to the queries array the function takes in because on page load, queries will be an empty array, effectively resetting it. If queries is an empty array, we initialize it here to an empty array. When queries is not empty, we will set it at the end of the function
+  // to allow users to remove queries, we separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed by comparies the queries that come in as an arguement to the queries that were previously selected
+  // once we have the query keys that were removed, we update the storage to be: union of what's currently stored and what was added. Less any queries that were removed
+  
+  // clear session queries when first invoked:
   if (queries.length === 0) {
-    await chrome.storage.local.set({ thisSessionsQueries: queries });
+    await chrome.storage.local.set({
+      thisSessionsQueries: []
+    });
   }
 
-  // to allow users to remove queries, we will separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed
   const queriesSet = new Set(queries);
-  chrome.storage.local.get(['thisSessionsQueries'], (result) => {
-    if (
-      result.thisSessionsQueries &&
-      Array.isArray(result.thisSessionsQueries)
-    ) {
-      const queriesRemoved: string[] = [];
-      for (const queryKey of result.thisSessionsQueries) {
-        if (!queriesSet.has(queryKey)) {
-          queriesRemoved.push(queryKey);
-        }
-      }
+  const sessionResult = await chrome.storage.local.get(['thisSessionsQueries']);
+  
+  // if no queries have been stored as part of the session set to an empty array
+  const sessionQueries: string[] =
+    sessionResult.thisSessionsQueries ?
+      sessionResult.thisSessionsQueries :
+      [];
 
-      // get the query keys that were stored from previous sessions
-      chrome.storage.local.get(['selectedQueries'], (result) => {
-        // get the queries out of local storage and store them as an array
-        let existingQueries: string[] = [];
-        if (result.selectedQueries && Array.isArray(result.selectedQueries)) {
-          existingQueries = result.selectedQueries;
-        }
+  // determine the queries that the user removed by finding the difference between the queries passed into the function and the queries stored as SessionQueries
+  // I'm currently marking queries as removed 
+  const queriesRemoved: string[] = sessionQueries.filter( queryKey => !queriesSet.has(queryKey))
+  console.log('queriesRemoved: ', queriesRemoved );
 
-        // combine existing queries with the new ones and handle duplicates
-        const combinedQueries = new Set([...existingQueries, ...queries]);
-        // remove the queries that users unselected
-        const combinedQueriesWithRemovals: string[] = [];
-        for (const queryKey of combinedQueries) {
-          // if queryKey is not in the removals list, add it to be stored
-          if (!queriesRemoved.includes(queryKey)) {
-            // store as a set for faster access
-            combinedQueriesWithRemovals.push(queryKey);
-          }
-        }
-
-        // add the combinedQueries into local storage
-        chrome.storage.local.set({
-          selectedQueries: combinedQueriesWithRemovals,
-        });
-
-        // update storage for current session's selections
-        chrome.storage.local.set({ thisSessionsQueries: queries });
-      });
-    }
+  // update storage for current session's selections now that we've found if any query keys were removed 
+  console.log('queries: ', queries);
+  await chrome.storage.local.set({
+    thisSessionsQueries: queries
   });
+
+
+  // get the query keys that were selected in previous sessions
+  const selectedResult = await chrome.storage.local.get(['selectedQueries'])
+  console.log('From previous session: ', selectedResult.selectedQueries);
+
+  // if no queries have been stored as part of previous sessions set to an empty array
+  const selectedQueries: string[] =
+    selectedResult.selectedQueries ?
+      selectedResult.selectedQueries :
+      [];
+
+  // combine existing queries with the new ones and handle duplicates
+  const combinedQueries = new Set([...selectedQueries, ...queries]);
+  console.log('combinedQueries: ', selectedQueries);
+
+  // remove the queries that users unselected
+  const combinedQueriesWithRemovals: string[] = [];
+  for (const queryKey of combinedQueries) {
+    // if queryKey is not in the removals list, add it to be stored
+    if (!queriesRemoved.includes(queryKey)) {
+      // store as a set for faster access
+      combinedQueriesWithRemovals.push(queryKey);
+    }
+  }
+
+  // add the combinedQueries into local storage
+  console.log('combinedQueriesWithRemovals: ', combinedQueriesWithRemovals);
+  await chrome.storage.local.set({
+    selectedQueries: combinedQueriesWithRemovals,
+  });
+
+  // TESTING - delete later
+  const finalSessionResult = await chrome.storage.local.get(['thisSessionsQueries']);
+  console.log('SessionQueries AFTER: ', finalSessionResult.thisSessionsQueries);
+  const finalResult = await chrome.storage.local.get(['selectedQueries']);
+  console.log('final AFTER: ', finalResult.selectedQueries);
 };
 
 export default saveSelectedQueryKeys;

--- a/src/functions/saveSelectedQueryKeys.ts
+++ b/src/functions/saveSelectedQueryKeys.ts
@@ -1,0 +1,59 @@
+
+const saveSelectedQueryKeys = async (queries: string[]) => {
+    // *** Persisting Query Selection ***
+    // this is complex because we may store queries that are not yet visible in the drop-down
+
+    // *** Refactor notes: handle errors (maybe update to promises)
+
+    // set thisSessionsQueries to the queries array the function takes in because on page load, queries will be an empty array, effectively resetting it. If queries is an empty array, we initialize it here to an empty array. When queries is not empty, we will set it at the end of the function
+    if (queries.length === 0) {
+      await chrome.storage.local.set({ thisSessionsQueries: queries });
+    }
+
+    // to allow users to remove queries, we will separately store the data from the session as "thisSessionsQueries" - this will allow us to see when a query has been removed
+    const queriesSet = new Set(queries);
+    chrome.storage.local.get(['thisSessionsQueries'], (result) => {
+      if (
+        result.thisSessionsQueries &&
+        Array.isArray(result.thisSessionsQueries)
+      ) {
+        const queriesRemoved: string[] = [];
+        for (const queryKey of result.thisSessionsQueries) {
+          if (!queriesSet.has(queryKey)) {
+            queriesRemoved.push(queryKey);
+          }
+        }
+
+        // get the query keys that were stored from previous sessions
+        chrome.storage.local.get(['selectedQueries'], (result) => {
+          // get the queries out of local storage and store them as an array
+          let existingQueries: string[] = [];
+          if (result.selectedQueries && Array.isArray(result.selectedQueries)) {
+            existingQueries = result.selectedQueries;
+          }
+
+          // combine existing queries with the new ones and handle duplicates
+          const combinedQueries = new Set([...existingQueries, ...queries]);
+          // remove the queries that users unselected
+          const combinedQueriesWithRemovals: string[] = [];
+          for (const queryKey of combinedQueries) {
+            // if queryKey is not in the removals list, add it to be stored
+            if (!queriesRemoved.includes(queryKey)) {
+              // store as a set for faster access
+              combinedQueriesWithRemovals.push(queryKey);
+            }
+          }
+
+          // add the combinedQueries into local storage
+          chrome.storage.local.set({
+            selectedQueries: combinedQueriesWithRemovals,
+          });
+
+          // update storage for current session's selections
+          chrome.storage.local.set({ thisSessionsQueries: queries });
+        });
+      }
+    });
+  };
+
+export default saveSelectedQueryKeys;

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,8 +3,6 @@ import { dark, light } from '@mui/material/styles/createPalette';
 
 const darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? true : false;
 
-console.log('Dark Mode: ', darkMode);
-
 const theme: ThemeOptions = createTheme({
   palette: {
     mode: darkMode ? 'dark' : 'light', // dynamically determine mode

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,8 +38,20 @@ export type SliderSectionProps = {
   isPlaying: boolean;
 };
 
-// variable types
+export type JsonFormatterType = {
+  jsonData: JsonDataType;
+  queryKey: string;
+  expandNodesFunc?: ExpandNodesFuncType; // this should be required but getting errors when it's not
+};
 
+export type JsonDiffType = {
+  oldJson?: JsonDataType | string, // optional in case you're on first state
+  currentJson: JsonDataType | string, // or string since state gets initialized to an empty string
+  queryKey: string,
+  isHidden: boolean
+};
+
+// variable types
 export type QueryEvent = {
   eventType: string;
   queryKey: string[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -58,3 +58,15 @@ export type QueryDisplay = {
   queryKey: string;
   queryData: any;
 };
+
+export type JsonDataType = {
+  [key: string]: any;
+};
+
+// function types
+
+export type ExpandNodesFuncType = (
+  keyPath: ReadonlyArray<string | number>,
+  value: any,
+  layer: number
+) => boolean


### PR DESCRIPTION
- Refactored handling of query keys between state to be promised based and added basic unit tests
- Added github action to run tests on PR
- Modified Json tabs to centrally manage types in the types folder